### PR TITLE
Enable VGA output over DVI-I port

### DIFF
--- a/spinal/sw/dvi.c
+++ b/spinal/sw/dvi.c
@@ -22,6 +22,8 @@ void dvi_ctrl_init()
         {   0x1d,       0x40},              // internal clock delay
         {   0x1f,       0x80},              // input data format. Bit 4: vsp, bit 4: hsp
 
+        {   0x21,       0x09},              // Enable VGA
+
 #if 0
         // clk <= 65Mhz
         {   0x33,       0x08},              // charge pump settings. See table 10


### PR DESCRIPTION
Tested on my Pano G2 rev. C. Works under 1080p.